### PR TITLE
Convert carboy to a pseudo-element background image

### DIFF
--- a/BauerBrewing.css
+++ b/BauerBrewing.css
@@ -31,7 +31,7 @@ header {
     display: flex;
     justify-content: flex-end;
     align-items: center;
-    padding: 30px 10%; 
+    padding: 30px 10%;
     background-color: #474853;
 }
 
@@ -64,7 +64,7 @@ button {
 
 /* Main Body */
 
-.body { 
+body {
     display: flex;
     flex-direction: column;
     min-height: 100vh;
@@ -74,6 +74,21 @@ button {
     color:linen;
     flex: 1;
     justify-content: center;
+    position: relative;
+}
+
+.main-content::before {
+    content: "";
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    background-image: url("carboy.jpg");
+    background-repeat: no-repeat;
+    background-position: center center;
+    background-size: cover;
+    opacity: 0.8;
 }
 
 .title {
@@ -102,8 +117,8 @@ button {
     size: cover;
     position: absolute;
     max-width: 100%;
-    opacity: 80%; 
-} 
+    opacity: 80%;
+}
 
 
 /**.beer_mug {
@@ -127,7 +142,7 @@ button {
 /** Media Queries **/
 
 @media only screen and (min-width: 480px) {
-   
+
 
 }
 

--- a/BauerBrewing.html
+++ b/BauerBrewing.html
@@ -24,19 +24,18 @@
             <a class="cta" href="#"><button>Contact</button></a>
         </header>
 
-<!--- Main Body /> --> 
-<img class="carboy" src="carboy.jpg" alt="Carboy Fermenter" />   
+<!--- Main Body /> -->
 <div class="main-content">
                     <h1 class="title">
                         Welcome to Homebrewing
                         <div class="boxed">
-                        in Small Spaces 
+                        in Small Spaces
                         </div>
                     </h1>
 
                     <div class="about">
                     <p>
-                        This website is dedicated to established and inspiring homebrewers who have limited space, 
+                        This website is dedicated to established and inspiring homebrewers who have limited space,
                         but unlimited dreams!
                     </p>
                      <h2>
@@ -44,7 +43,7 @@
                     </h2>
                      <p>
                         My name is Rachel and I have been homebrewing for a few years now.  While I do not consider myself an expert, the purpose of creating this website is to insipire other small-home dwellers
-                        to begin the journey of homebrewing. <br /> My homebrewing journey begain shortly after purchasing a one-gallon homebrewing kit for my husband for Christmas.  We had recently seen a demonstration at a 
+                        to begin the journey of homebrewing. <br /> My homebrewing journey begain shortly after purchasing a one-gallon homebrewing kit for my husband for Christmas.  We had recently seen a demonstration at a
                         local brewery and I was facinated by how easy it looked.  After we brewed our first beer together I was hooked!  I got my very own carboy and supplies and immediately started writing recipies.  The possibilities were endless!
                         My first beer was a play on the Samyang Fire Noodles (cream ale with a dash of the nuclear fire noodle sauce).  Was it great? Not really. Was it exciting? Absolutely!  If you are new to the homebrewing world, know that you will make mistakes.
                          You will make bad beer, we all have. We also have all made great beer and isn't the world and every small corner in it a better place with great beer?  Yes, yes it is.
@@ -60,7 +59,7 @@
             <div class="footer-inner">
                 <span>Copyright &copy; 2020 Rachel Bauer</span> <br />
                 <a href="https://www.freepik.com/free-vector/beer-mug-with-froth-brick-background-neon-style-illustration-pub-bar-oktoberfest_2553172.htm#page=1&query=beer%20mug%20brick&position=3">Logo image created by katemangostar - www.freepik.com</a>
-            </div>    
+            </div>
         </footer>
 
     </div>


### PR DESCRIPTION
Hi Rachel,
Funny enough, you can practice your CSS _and_ your GitHub skills with this!

Sorry for the distracting whitespace changes (my code editor did those by default) but you can see in the line-by-line changes here that I've:

- removed the `.` before the `body` CSS rule to make the footer sticky again
- removed carboy.jpg as a literal `<img>` in the HTML file
- created a ["pseudo-element"](https://developer.mozilla.org/en-US/docs/Web/CSS/::before) that is absolutely-positioned so that it can always be the same size as the `.main-content` div, and set carboy as a `background-image` on that pseudo-element.

The combination of pseudo-element and background-image might make this a little confusing/advanced, but this would be a more stable solution for what you're trying to do. Happy to talk about this further if you have any questions or want to experiment with other ways than this!